### PR TITLE
[FEAT] gemini api 호출 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.20.160')
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:auth'
+
+    // WebClient for HTTP calls
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/loopon/journey/application/dto/request/JourneyGenerationRequest.java
+++ b/src/main/java/com/loopon/journey/application/dto/request/JourneyGenerationRequest.java
@@ -1,0 +1,10 @@
+package com.loopon.journey.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record JourneyGenerationRequest(
+        @NotBlank(message = "목표는 비어있을 수 없습니다.")
+        @Size(max = 255, message = "목표는 255자 이하여야 합니다.")
+        String goal
+) {}

--- a/src/main/java/com/loopon/journey/application/dto/request/JourneyRegenerationRequest.java
+++ b/src/main/java/com/loopon/journey/application/dto/request/JourneyRegenerationRequest.java
@@ -1,0 +1,16 @@
+package com.loopon.journey.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record JourneyRegenerationRequest(
+        @NotBlank(message = "목표는 비어있을 수 없습니다.")
+        @Size(max = 255, message = "목표는 255자 이하여야 합니다.")
+        String goal,
+
+        @NotEmpty(message = "제외할 여정 목록은 비어있을 수 없습니다.")
+        List<String> excludeJourneyTitles
+) {}

--- a/src/main/java/com/loopon/journey/application/dto/response/JourneyGenerationResponse.java
+++ b/src/main/java/com/loopon/journey/application/dto/response/JourneyGenerationResponse.java
@@ -1,0 +1,7 @@
+package com.loopon.journey.application.dto.response;
+
+import java.util.List;
+
+public record JourneyGenerationResponse(
+        List<String> journeys
+) {}

--- a/src/main/java/com/loopon/journey/application/service/JourneyGenerationService.java
+++ b/src/main/java/com/loopon/journey/application/service/JourneyGenerationService.java
@@ -1,0 +1,27 @@
+package com.loopon.journey.application.service;
+
+import com.loopon.journey.application.dto.response.JourneyGenerationResponse;
+import com.loopon.journey.infrastructure.llm.GeminiClient;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class JourneyGenerationService {
+
+    private final GeminiClient geminiClient;
+
+    public JourneyGenerationService(GeminiClient geminiClient) {
+        this.geminiClient = geminiClient;
+    }
+
+    public JourneyGenerationResponse generateJourneys(String goal) {
+        List<String> journeys = geminiClient.generateMultipleJourneys(goal);
+        return new JourneyGenerationResponse(journeys);
+    }
+
+    public JourneyGenerationResponse regenerateJourneys(String goal, List<String> excludeJourneyTitles) {
+        List<String> journeys = geminiClient.regenerateJourneys(goal, excludeJourneyTitles);
+        return new JourneyGenerationResponse(journeys);
+    }
+}

--- a/src/main/java/com/loopon/journey/infrastructure/llm/GeminiClient.java
+++ b/src/main/java/com/loopon/journey/infrastructure/llm/GeminiClient.java
@@ -1,0 +1,98 @@
+package com.loopon.journey.infrastructure.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class GeminiClient {
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+
+    public GeminiClient(String apiKey) {
+        this.apiKey = apiKey;
+        this.webClient = WebClient.builder()
+                .baseUrl("https://generativelanguage.googleapis.com")
+                .build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public List<String> generateMultipleJourneys(String goal) {
+        String prompt = String.format("""
+            사용자의 목표가 "%s"일 때, 이 목표를 달성하기 위한 5개의 구체적인 여정(journey)을 생성해주세요.
+            
+            각 여정은 다음 형식을 따라야 합니다:
+            1. [여정 제목]: [여정 설명]
+            
+            여정은 현실적이고 구체적이어야 하며, 목표 달성에 실제로 도움이 되어야 합니다.
+            한국어로 응답해주세요.
+            """, goal);
+
+        String response = generateText(prompt);
+        return parseJourneyResponse(response);
+    }
+
+    public List<String> regenerateJourneys(String goal, List<String> existingJourneyTitles) {
+        String excludeList = existingJourneyTitles.stream()
+                .map(title -> "- " + title)
+                .collect(Collectors.joining("\n"));
+
+        String prompt = String.format("""
+            사용자의 목표가 "%s"일 때, 다음 기존 여정들을 제외하고 5개의 새로운 여정(journey)을 생성해주세요:
+            
+            %s
+            
+            각 여정은 다음 형식을 따라야 합니다:
+            1. [여정 제목]: [여정 설명]
+            
+            여정은 현실적이고 구체적이어야 하며, 기존 여정과는 다른 새로운 접근 방식을 제안해야 합니다.
+            한국어로 응답해주세요.
+            """, goal, excludeList);
+
+        String response = generateText(prompt);
+        return parseJourneyResponse(response);
+    }
+
+    private String generateText(String prompt) {
+        try {
+            Map<String, Object> requestBody = Map.of(
+                    "contents", List.of(
+                            Map.of("parts", List.of(
+                                    Map.of("text", prompt)
+                            ))
+                    )
+            );
+
+            String response = webClient.post()
+                    .uri("/v1beta/models/gemini-1.5-flash:generateContent?key=" + apiKey)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            JsonNode jsonNode = objectMapper.readTree(response);
+            return jsonNode.path("candidates")
+                    .get(0)
+                    .path("content")
+                    .path("parts")
+                    .get(0)
+                    .path("text")
+                    .asText();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate text from Gemini API", e);
+        }
+    }
+
+    private List<String> parseJourneyResponse(String response) {
+        return response.lines()
+                .filter(line -> line.matches("^\\d+\\..*"))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/loopon/journey/infrastructure/llm/GeminiConfig.java
+++ b/src/main/java/com/loopon/journey/infrastructure/llm/GeminiConfig.java
@@ -1,0 +1,17 @@
+package com.loopon.journey.infrastructure.llm;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GeminiConfig {
+
+    @Value("${gemini.api-key}")
+    private String apiKey;
+
+    @Bean
+    public GeminiClient geminiClient() {
+        return new GeminiClient(apiKey);
+    }
+}

--- a/src/main/java/com/loopon/journey/presentation/JourneyController.java
+++ b/src/main/java/com/loopon/journey/presentation/JourneyController.java
@@ -1,0 +1,56 @@
+package com.loopon.journey.presentation;
+
+import com.loopon.journey.application.dto.request.JourneyGenerationRequest;
+import com.loopon.journey.application.dto.request.JourneyRegenerationRequest;
+import com.loopon.journey.application.dto.response.JourneyGenerationResponse;
+import com.loopon.journey.application.service.JourneyGenerationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/journeys")
+@Tag(name = "Journey Generation", description = "여정 생성 API")
+public class JourneyController {
+
+    private final JourneyGenerationService journeyGenerationService;
+
+    public JourneyController(JourneyGenerationService journeyGenerationService) {
+        this.journeyGenerationService = journeyGenerationService;
+    }
+
+    @PostMapping("/generate")
+    @Operation(summary = "여정 생성", description = "목표를 기반으로 5개의 여정을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "여정 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<JourneyGenerationResponse> generateJourneys(
+            @Valid @RequestBody JourneyGenerationRequest request) {
+
+        JourneyGenerationResponse response = journeyGenerationService.generateJourneys(request.goal());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/regenerate")
+    @Operation(summary = "여정 재생성", description = "제외할 여정들을 제외하고 새로운 여정들을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "여정 재생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<JourneyGenerationResponse> regenerateJourneys(
+            @Valid @RequestBody JourneyRegenerationRequest request) {
+
+        JourneyGenerationResponse response = journeyGenerationService.regenerateJourneys(
+                request.goal(),
+                request.excludeJourneyTitles()
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -79,3 +79,6 @@ springdoc:
     display-request-duration: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+gemini:
+  api-key: ${GEMINI_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: loop-on
+gemini:
+  api-key: ${GEMINI_API_KEY}


### PR DESCRIPTION
## #⃣ 관련 이슈

Closes #58 

+(이슈번호 헷갈려서 브랜치명 58/... 인데 17/... 로 잘못 만들었어요)
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. LLM API 클라이언트 (GeminiClient)
Google Gemini API를 사용한 무료 LLM 연동
WebClient로 HTTP API 호출 구현
여정 생성 및 재생성 프롬프트 관리

2. 여정 생성 API (JourneyController)
POST /api/journeys/generate - 목표로 5개 여정 생성
POST /api/journeys/regenerate - 제외 여정 지정 후 재생성
Swagger 문서 생성

3. 서비스 로직 (JourneyGenerationService)
목표 기반 여정 생성 비즈니스 로직
기존 여정 제외하고 새로운 여정 생성 기능

## Check list
- [ ] 테스트 통과 확인
- [x] 모든 commit이 push 확인
- [x] merge branch 확인

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
