### PR TITLE
[FEAT] 여정여권에서 해당여정 이어가기 api 추가

### DIFF
--- a/src/main/java/com/loopon/journey/application/dto/response/JourneyContinuationResponse.java
+++ b/src/main/java/com/loopon/journey/application/dto/response/JourneyContinuationResponse.java
@@ -1,0 +1,38 @@
+package com.loopon.journey.application.dto.response;
+
+import com.loopon.journey.domain.JourneyCategory;
+import com.loopon.journey.domain.JourneyStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JourneyContinuationResponse {
+    private Long goalId;
+    private String mainGoal;
+    private List<JourneyStamp> journeyStamps;
+    private int completedCount;
+    private int totalCount;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JourneyStamp {
+        private Long journeyId;
+        private String goal;
+        private JourneyCategory category;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private JourneyStatus status;
+        private boolean isCompleted;
+        private int order;
+    }
+}

--- a/src/main/java/com/loopon/journey/application/dto/response/JourneyContinueResponse.java
+++ b/src/main/java/com/loopon/journey/application/dto/response/JourneyContinueResponse.java
@@ -1,0 +1,16 @@
+package com.loopon.journey.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JourneyContinueResponse {
+    private String goal;
+    private boolean isContinuation;
+    private Long originalJourneyId;
+}

--- a/src/main/java/com/loopon/journey/application/service/JourneyContinueService.java
+++ b/src/main/java/com/loopon/journey/application/service/JourneyContinueService.java
@@ -1,0 +1,32 @@
+package com.loopon.journey.application.service;
+
+import com.loopon.journey.application.dto.response.JourneyContinueResponse;
+import com.loopon.journey.domain.Journey;
+import com.loopon.journey.domain.repository.JourneyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JourneyContinueService {
+
+    private final JourneyRepository journeyRepository;
+
+    public JourneyContinueResponse continueJourney(Long journeyId, Long userId) {
+        // 1. 기존 여정 조회
+        Journey originalJourney = journeyRepository.findById(journeyId)
+                .orElseThrow(() -> new RuntimeException("Journey not found"));
+
+        // 2. 권한 확인
+        if (!originalJourney.getUser().getId().equals(userId)) {
+            throw new RuntimeException("Unauthorized access to journey");
+        }
+
+        // 3. 기존 목표를 그대로 반환 (새로운 여정 생성을 위한 데이터)
+        return JourneyContinueResponse.builder()
+                .goal(originalJourney.getGoal())
+                .isContinuation(true)
+                .originalJourneyId(originalJourney.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/loopon/journey/presentation/JourneyApiController.java
+++ b/src/main/java/com/loopon/journey/presentation/JourneyApiController.java
@@ -5,8 +5,10 @@ import com.loopon.global.security.principal.PrincipalDetails;
 import com.loopon.journey.application.dto.command.JourneyCommand;
 import com.loopon.journey.application.dto.request.JourneyRequest;
 import com.loopon.journey.application.dto.request.LoopRegenerationRequest;
+import com.loopon.journey.application.dto.response.JourneyContinueResponse;
 import com.loopon.journey.application.dto.response.JourneyResponse;
 import com.loopon.journey.application.dto.response.LoopRegenerationResponse;
+import com.loopon.journey.application.service.JourneyContinueService;
 import com.loopon.journey.application.service.LoopRegenerationService;
 import com.loopon.journey.domain.service.JourneyCommandService;
 import com.loopon.journey.domain.service.JourneyQueryService;
@@ -30,6 +32,7 @@ public class JourneyApiController implements JourneyApiDocs {
     private final JourneyCommandService journeyCommandService;
     private final JourneyQueryService journeyQueryService;
     private final LoopRegenerationService loopRegenerationService;
+    private final JourneyContinueService journeyContinueService;
 
     @Override
     @PostMapping("/goals")
@@ -91,6 +94,17 @@ public class JourneyApiController implements JourneyApiDocs {
             @Valid @RequestBody LoopRegenerationRequest request
     ) {
         LoopRegenerationResponse response = loopRegenerationService.regenerateLoop(request);
+
+        return ResponseEntity.ok(CommonResponse.onSuccess(response));
+    }
+
+    @PostMapping("/{journeyId}/continue")
+    public ResponseEntity<CommonResponse<JourneyContinueResponse>> continueJourney(
+            @PathVariable Long journeyId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Long userId = principalDetails.getUserId();
+        JourneyContinueResponse response = journeyContinueService.continueJourney(journeyId, userId);
 
         return ResponseEntity.ok(CommonResponse.onSuccess(response));
     }


### PR DESCRIPTION
## #⃣ 관련 이슈

Closes #100

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

여정 이어가기
기존 여정의 목표를 그대로 가져와 새로운 여정 생성을 위한 데이터를 반환합니다

## Check list
- [x] 테스트 통과 확인
- [x] 모든 commit이 push 확인
- [x] merge branch 확인

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
